### PR TITLE
Close each video clip file

### DIFF
--- a/ELAN_make_subtitles.py
+++ b/ELAN_make_subtitles.py
@@ -87,6 +87,7 @@ def make_video(videofile,clip,num,speed):
 	video = CompositeVideoClip([v]+subs).speedx(speed/100)
 	clipfile = videofile.split(".")[0]+"_subtitles_"+str(num+1)+".mp4"
 	video.write_videofile(clipfile,temp_audiofile="temp-audio.m4a", remove_temp=True, codec="libx264", audio_codec="aac")
+	v.close()
 
 def make_all_clips(tiername,speed):
 	"""


### PR DESCRIPTION
Fixes "OSError: [WinError 6] The handle is invalid" on Windows.

```
Traceback (most recent call last):
  File "ELAN_make_subtitles.py", line 115, in <module>
    main()
  File "ELAN_make_subtitles.py", line 112, in main
    make_all_clips(args.tiername,args.speed)
  File "ELAN_make_subtitles.py", line 102, in make_all_clips
    make_video(v,c,num,speed)
  File "ELAN_make_subtitles.py", line 71, in make_video
    v = VideoFileClip(videofile).subclip(t1,t2)
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\site-packages\moviepy\video\io\VideoFileClip.py", line 91, in __init__
    fps_source=fps_source)
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\site-packages\moviepy\video\io\ffmpeg_reader.py", line 33, in __init__
    fps_source)
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\site-packages\moviepy\video\io\ffmpeg_reader.py", line 256, in ffmpeg_parse_infos
    proc = sp.Popen(cmd, **popen_params)
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 664, in __init__
    _cleanup()
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 228, in _cleanup
    res = inst._internal_poll(_deadstate=sys.maxsize)
  File "C:\Users\benjamin\AppData\Local\Programs\Python\Python37-32\lib\subprocess.py", line 1216, in _internal_poll
    if _WaitForSingleObject(self._handle, 0) == _WAIT_OBJECT_0:
OSError: [WinError 6] The handle is invalid
```
Followed suggested fix here: https://stackoverflow.com/a/45393619